### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/top-level-configs/variants/club.nix
+++ b/top-level-configs/variants/club.nix
@@ -70,7 +70,7 @@
 		};
 	};
 	
-	# https://nixos.wiki/wiki/Bluetooth
+	# https://wiki.nixos.org/wiki/Bluetooth
 	hardware.bluetooth.enable = true;
 	programs.zsh.enable = true; 
 	users ={

--- a/top-level-configs/variants/gcloud.nix
+++ b/top-level-configs/variants/gcloud.nix
@@ -85,7 +85,7 @@ in
 
 	}; # END SERVICES
 
-	# https://nixos.wiki/wiki/Bluetooth
+	# https://wiki.nixos.org/wiki/Bluetooth
 	hardware.bluetooth.enable = false;
 
 	users ={


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️